### PR TITLE
Nil error fix, more useful 'timestamp' attr on Candle objects

### DIFF
--- a/lib/rtcbx.rb
+++ b/lib/rtcbx.rb
@@ -30,7 +30,7 @@ class RTCBX
     @api_secret     = options.fetch(:api_secret, '')
     @api_passphrase = options.fetch(:api_passphrase, '')
     @message_callbacks = []
-    @message_callbacks << block
+    @message_callbacks << block if block_given?
     @client = Coinbase::Exchange::Client.new(
       api_key,
       api_secret,

--- a/lib/rtcbx/candles/candle.rb
+++ b/lib/rtcbx/candles/candle.rb
@@ -5,7 +5,7 @@ class RTCBX
       attr_reader :time, :low, :high, :open, :close, :volume
 
       def initialize(epoch, matches)
-        @time = epoch
+        @time = Time.at(epoch)
         @low = matches.map {|message| BigDecimal.new(message.fetch('price'))}.min
         @high = matches.map {|message| BigDecimal.new(message.fetch('price'))}.max
         @open = BigDecimal.new(matches.first.fetch('price'))


### PR DESCRIPTION
Using epoch for time was kind of lame, so Candle timestamp attr is now a TIme object.

If you started a Candle object without passing a block, you'd get a nil error when processing the first candle. It's now fixed.