### PR TITLE
Fixed last_pong

### DIFF
--- a/lib/rtcbx.rb
+++ b/lib/rtcbx.rb
@@ -82,7 +82,7 @@ class RTCBX
   def setup_ping_timer
     EM.add_periodic_timer(PING_INTERVAL) do
       websocket.ping do
-        last_pong = Time.now
+        @last_pong = Time.now
       end
     end
   end


### PR DESCRIPTION
`last_pong` was always returning `nil` because the last websocket ping time wasn't stored in a class variable.